### PR TITLE
fix: adding service to get issues by user_id

### DIFF
--- a/microservices/issues_management/src/repositories/base.py
+++ b/microservices/issues_management/src/repositories/base.py
@@ -14,8 +14,8 @@ class BaseRepository(ABC):
     model = None
     serializer = None
 
-    def __init__(self):
-        self.session = SessionLocal()
+    def __init__(self, session=None):
+        self.session = session or SessionLocal()
 
         self.operator_map = {
             "eq": lambda field, value: field == value,

--- a/microservices/issues_management/src/repositories/issues_repository.py
+++ b/microservices/issues_management/src/repositories/issues_repository.py
@@ -5,5 +5,5 @@ from src.repositories.base import BaseRepository
 class IssuesManagementRepository(BaseRepository):
     model = Issue
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, session=None):
+        super().__init__(session=session)

--- a/microservices/issues_management/src/routes.py
+++ b/microservices/issues_management/src/routes.py
@@ -15,6 +15,7 @@ from src.services import get_all_issues_service
 from src.services import get_issue_call_service
 from src.services import get_issue_open_service
 from src.services import get_issue_service
+from src.services import get_issues_by_user_service
 
 blueprint = Blueprint("issues_management_api", __name__, url_prefix="/issues_management")
 
@@ -24,6 +25,9 @@ blueprint = Blueprint("issues_management_api", __name__, url_prefix="/issues_man
 @jwt_required()
 # @validate_permissions([Permissions.VIEW_ISSUE.value])
 def get_issues():
+    query_params = request.args.to_dict()
+    if "user_id" in query_params:
+        return get_issues_by_user_service(query_params["user_id"]), HTTPStatus.OK
     return get_all_issues_service(), HTTPStatus.OK
 
 

--- a/microservices/issues_management/src/services.py
+++ b/microservices/issues_management/src/services.py
@@ -35,6 +35,16 @@ def get_issue_service(issue_id):
     return response
 
 
+def get_issues_by_user_service(user_id):
+    issue_repository = IssuesManagementRepository()
+    issue_repository.set_serializer(serializer_class)
+    filter_dict = {"user_id": ("eq", user_id)}
+    issues = issue_repository.get_by_query(filter_dict)
+    response_entity = GenericResponseListEntity(data=issues, count=len(issues))
+    response = GenericResponseListSerializer().dump(response_entity)
+    return response
+
+
 def get_issue_open_service(user_id):
     issue_repository = IssuesManagementRepository()
     issue_repository.set_serializer(serializer_class)


### PR DESCRIPTION
Para obtener todos los incidentes de un usuario, se debe pasar el user_id como query param.

Petición: GET` /issues_management?user_id=<Id del usuario>`

Cierra el issue: #26 